### PR TITLE
Develop

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,8 +6,7 @@
     },
     "extends": [
         "eslint:recommended",
-        "plugin:react/recommended",
-        "plugin:prettier/recommended"
+        "plugin:react/recommended"
     ],
     "parserOptions": {
         "ecmaFeatures": {

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 .vscode
+.eslintrc.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
         "source.fixAll.eslint": true
     },
     "eslint.workingDirectories": [
-        "./{PATH_TO_CLIENT}"
+        {"mode":"auto"}
     ]
     //"eslint.alwaysShowStatus": true,
     // "files.autoSave": "onFocusChange"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10843,6 +10843,30 @@
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
     },
+    "path": {
+      "version": "0.12.7",
+      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
+      "integrity": "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=",
+      "requires": {
+        "process": "^0.11.1",
+        "util": "^0.10.3"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        },
+        "util": {
+          "version": "0.10.4",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+          "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+          "requires": {
+            "inherits": "2.0.3"
+          }
+        }
+      }
+    },
     "path-browserify": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "web-vitals": "^1.1.1"
   },
   "scripts": {
-    "start": "node server.js",
+    "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
@@ -41,9 +41,6 @@
   },
   "devDependencies": {
     "eslint": "^7.22.0",
-    "eslint-config-prettier": "^8.1.0",
-    "eslint-plugin-prettier": "^3.3.1",
-    "eslint-plugin-react": "^7.22.0",
-    "prettier": "^2.2.1"
+    "eslint-plugin-react": "^7.22.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
     "@testing-library/jest-dom": "^5.11.9",
     "@testing-library/react": "^11.2.5",
     "@testing-library/user-event": "^12.8.3",
+    "dotenv": "^8.2.0",
+    "express": "^4.17.1",
+    "path": "^0.12.7",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-router-dom": "^5.2.0",
@@ -13,7 +16,7 @@
     "web-vitals": "^1.1.1"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "node server.js",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"

--- a/server.js
+++ b/server.js
@@ -1,0 +1,27 @@
+const express = require("express");
+const path = require("path");
+const dotenv = require("dotenv");
+// const cors = require("cors")
+const app = express();
+app.use(express.urlencoded({ extended: true }));
+app.use(express.static("public"));
+app.use(express.json());
+// app.use(cors())
+
+app.get("/", (req, res) => {
+  //serve up index.html
+  res.sendFile(__dirname + "/index.html");
+});
+
+// app.get('/js/main.js', (req, res) => {
+//     //serve up index.html
+//     res.sendFile(__dirname+'/js/main.js')
+// })
+
+const PORT = 3000;
+
+app.listen(process.env.PORT || PORT, () => {
+  //some callback
+  //let them know we're alive
+  console.log(`We're live on port ${PORT}`);
+});


### PR DESCRIPTION
Wasn't building on Heroku.
Heroku error: 
"heroku" Failed to load plugin 'prettier' declared in '.eslintrc.json': Cannot find module 'eslint-plugin-prettier'
My theory is that the problem is that it's looking for eslint in production, and you don't want that in production, and/or that I should set up the server to be referencing the production build that Heroku creates when it deploys. 
OR: it's a conflict between eslint and prettier, but I had the eslint-prettier package that's supposed to make that go away. 
In the end, I removed prettier. 
Also added node and a few other node-related things. Maybe I'll use that in the future, so might as well. 
Also, I'm not sure what the starter script should be. I reset it to script: "react-scripts start" , but maybe it should be "node server.js"?
